### PR TITLE
[3085] 사탕 게임: 브루트포스 (1시간 21분)

### DIFF
--- a/PJH/baekjoon/3085.js
+++ b/PJH/baekjoon/3085.js
@@ -1,0 +1,61 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+function exchange(x1, y1, x2, y2) {
+  [candy[x1][y1], candy[x2][y2]] = [candy[x2][y2], candy[x1][y1]];
+}
+
+function getMaxCandyCount() {
+  let max = 0;
+
+  // row
+  for (let i = 0; i < N; i++) {
+    let count = 1;
+
+    for (let j = 1; j < N; j++) {
+      if (candy[i][j] === candy[i][j - 1]) {
+        count++;
+        max = Math.max(max, count);
+      } else count = 1;
+    }
+  }
+
+  // col
+  for (let j = 0; j < N; j++) {
+    let count = 1;
+
+    for (let i = 1; i < N; i++) {
+      if (candy[i][j] === candy[i - 1][j]) {
+        count++;
+        max = Math.max(max, count);
+      } else count = 1;
+    }
+  }
+
+  return max;
+}
+
+const N = Number(input[0]);
+const candy = input.slice(1).map((row) => row.split(""));
+let maxCandy = 0;
+
+for (let i = 0; i < N; i++) {
+  for (let j = 0; j < N; j++) {
+    // 오른쪽
+    if (j + 1 < N && candy[i][j] !== candy[i][j + 1]) {
+      exchange(i, j, i, j + 1);
+      maxCandy = Math.max(maxCandy, getMaxCandyCount());
+      exchange(i, j, i, j + 1);
+    }
+
+    // 아래쪽
+    if (i + 1 < N && candy[i][j] !== candy[i + 1][j]) {
+      exchange(i, j, i + 1, j);
+      maxCandy = Math.max(maxCandy, getMaxCandyCount());
+      exchange(i, j, i + 1, j);
+    }
+  }
+}
+
+console.log(maxCandy);


### PR DESCRIPTION
## [3085] 사탕 게임: 브루트포스 (1시간 21분)

### 문제에 대한 한줄 요약
특정 사탕의 인접한(상하좌우) 부분의 사탕 중 다른 색상의 사탕끼리만 서로 교환하고 가장 긴 연속 색상(행 or 열)의 최대값을 찾는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 9분
- 2단계 (알고리즘 선택): 5분
- 3단계 (구현 및 테스트): 1시간
- 4단계 (디버깅 및 제출): 7분

### 느낀점
처음에 문제 이해를 잘못해서 "사탕의 색이 다른 인접한 두 칸"을 고르는 것이 아니라 "사탕의 색이 다른 두 칸"을 고르는 건줄 알고 삽질을 좀 했습니다.
먼저 인접한 두 사탕을 고르고 위치를 교환한 후 해당 배열에서 나올 수 있는 최대 값을 `maxCandy` 변수에 갱신하고 다시 원래대로 위치를 교환하는 방식으로 구현했습니다.

인접한 칸을 선택할 때는 오른쪽 아래쪽만 선택하여 중복을 최소화했습니다. (어차피 왼쪽 위쪽은 이전에 방문했을 때 비교했으므로)

어려운 문제는 아니였지만 문제를 정확히 이해하지 못해서 시간이 많이 소요되었네요. 좀 더 꼼꼼히 문제를 읽어보아야겠습니다.