### PR TITLE
PJH - [1743] 음식물 피하기: bfs, dfs (18분)

### DIFF
--- a/PJH/baekjoon/1743.js
+++ b/PJH/baekjoon/1743.js
@@ -1,0 +1,101 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+class Node {
+  constructor(data) {
+    this.data = data;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.front = null;
+    this.rear = null;
+    this.size = 0;
+  }
+
+  push(data) {
+    const newNode = new Node(data);
+
+    if (this.size === 0) {
+      this.front = newNode;
+      this.rear = newNode;
+    } else {
+      this.rear.next = newNode;
+      this.rear = newNode;
+    }
+
+    this.size++;
+  }
+
+  shift() {
+    if (this.size === 0) return null;
+
+    const data = this.front.data;
+
+    this.front = this.front.next;
+    this.size--;
+
+    return data;
+  }
+}
+
+function bfs(i, j) {
+  const queue = new Queue();
+  let count = 1;
+
+  queue.push([i, j]);
+  visited[i][j] = true;
+
+  while (queue.size) {
+    const [x, y] = queue.shift();
+
+    for (const [dx, dy] of directions) {
+      const nx = x + dx;
+      const ny = y + dy;
+
+      if (
+        nx < 0 ||
+        nx >= N ||
+        ny < 0 ||
+        ny >= M ||
+        !map[nx][ny] ||
+        visited[nx][ny]
+      ) {
+        continue;
+      }
+
+      queue.push([nx, ny]);
+      visited[nx][ny] = true;
+      count++;
+    }
+  }
+
+  return count;
+}
+
+const [N, M, K] = input[0].split(" ").map(Number);
+const coordinate = input.slice(1).map((row) => row.split(" ").map(Number));
+const map = Array.from({ length: N }, () => Array(M).fill(false));
+const visited = Array.from({ length: N }, () => Array(M).fill(false));
+const directions = [
+  [0, 1],
+  [1, 0],
+  [0, -1],
+  [-1, 0],
+];
+let max = 0;
+
+for (const [x, y] of coordinate) {
+  map[x - 1][y - 1] = true;
+}
+
+for (let i = 0; i < N; i++) {
+  for (let j = 0; j < M; j++) {
+    if (map[i][j]) max = Math.max(max, bfs(i, j));
+  }
+}
+
+console.log(max);

--- a/PJH/baekjoon/1743.js
+++ b/PJH/baekjoon/1743.js
@@ -94,7 +94,7 @@ for (const [x, y] of coordinate) {
 
 for (let i = 0; i < N; i++) {
   for (let j = 0; j < M; j++) {
-    if (map[i][j]) max = Math.max(max, bfs(i, j));
+    if (map[i][j] && !visited[i][j]) max = Math.max(max, bfs(i, j));
   }
 }
 


### PR DESCRIPTION
## [1743] 음식물 피하기: bfs, dfs (18분)

### 문제에 대한 한줄 요약
bfs나 dfs로 연결된 음식물들을 탐색하고, 제일 큰 음식물의 크기를 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 2분
- 2단계 (알고리즘 선택): 1분
- 3단계 (구현 및 테스트): 13분
- 4단계 (디버깅 및 제출): 1분

### 느낀점
기본적인 bfs, dfs 문제였습니다.
bfs를 이용해서 탐색할 때 마다 음식물의 개수를 카운트하여 최대 크기를 구하도록 구현했습니다.