### PR TITLE
PJH - [1342] 행운의 문자열: 백트래킹 (28분)

### DIFF
--- a/PJH/baekjoon/1342.js
+++ b/PJH/baekjoon/1342.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+const S = fs.readFileSync("input.txt").toString().trim().split(""); // local 파일
+// const S = fs.readFileSync(0, "utf-8").toString().trim().split(""); // 문제 제출 시
+
+function dfs(string, before, depth) {
+  if (depth === length) {
+    set.add(string);
+    return;
+  }
+
+  for (let i = 0; i < length; i++) {
+    const next = i;
+
+    if (visited[next] || S[before] === S[next]) continue;
+
+    visited[next] = true;
+    dfs(string + S[next], next, depth + 1);
+    visited[next] = false;
+  }
+}
+
+const length = S.length;
+const visited = Array(length).fill(false);
+const set = new Set();
+
+for (let i = 0; i < length; i++) {
+  visited[i] = true;
+  dfs(`${S[i]}`, i, 1);
+  visited[i] = false;
+}
+
+console.log(set.size);


### PR DESCRIPTION
## [1342] 행운의 문자열: 백트래킹 (28분)

### 문제에 대한 한줄 요약
인접해 있는 문자가 같지 않은 문자열을 만들 수 있는 최대 개수를 백트래킹을 이용해 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 2분
- 2단계 (알고리즘 선택): 1분
- 3단계 (구현 및 테스트): 19분
- 4단계 (디버깅 및 제출): 6분

### 느낀점
처음에 문제를 아래와 같이 접근했습니다.
```
1. 인접해 있는 문자가 같지 않아야 한다.
2. dfs를 통해 나올 수 있는 모든 조합을 확인한다.
3. dfs 중에 이전 문자와 현재 문자가 같으면 다음으로 넘어간다.
```
문제를 보고 딱 떠오른 방식이 dfs를 이용해서 나올 수 있는 모든 문자열의 조합을 구하는 방식이였습니다.
여기서 중요한 조건은 '인접한 문자열이 같지 않아야 한다' 이기 때문에 dfs 내에서 이전 문자열과 다음 문자열을 비교하여 둘이 같다면 패스하도록 했습니다.

처음에는 단순히 visited 배열만 사용해서 선택하였는지 확인한 후 조합하고 depth가 주어진 문자열의 길이와 같다면 카운트 하는 방식으로 구현하였는데, 다른 인덱스를 가지지만 같은 문자를 가지는 부분에 대해선 생각하지 못했습니다.

예를들어,
```
입력이 'aabbbaa' 일 때
행운의 문자열이 만들어 질 수 있는 조합은 '0213546', '1203546' 등이 있지만 모두 'abababa' 로 실제 문자열은 같습니다.
```

이런 중복을 제거하는 로직이 필요했고 카운트 방식이 아니라 `dfs()` 를 통해 만들어지는 문자열을 `set`에 담아서 중복을 제거한 후 `set`의 사이즈를 출력하도록 구현했습니다.

브루트포스로 순열을 구하는 문제여서 시간복잡도가 O(N!) 이라 시간초과가 뜰 줄 알았는데 입력 S의 최대 길이가 10이라
10! = 3,628,800 번이고 제한시간이 2초라 통과된거 같네요.