### PR TITLE
PJH - [18405] 경쟁적 전염: bfs (1시간 27분)

### DIFF
--- a/PJH/baekjoon/18405.js
+++ b/PJH/baekjoon/18405.js
@@ -1,0 +1,87 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+class Node {
+  constructor(data) {
+    this.data = data;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.front = null;
+    this.rear = null;
+    this.size = 0;
+  }
+
+  push(data) {
+    const newNode = new Node(data);
+
+    if (this.size === 0) {
+      this.front = newNode;
+      this.rear = newNode;
+    } else {
+      this.rear.next = newNode;
+      this.rear = newNode;
+    }
+
+    this.size++;
+  }
+
+  shift() {
+    if (this.size === 0) return null;
+
+    const data = this.front.data;
+
+    this.front = this.front.next;
+    this.size--;
+
+    return data;
+  }
+}
+
+const [N, K] = input[0].split(" ").map(Number);
+const map = input.slice(1, N + 1).map((row) => row.split(" ").map(Number));
+const [S, X, Y] = input[N + 1].split(" ").map(Number);
+const directions = [
+  [0, 1],
+  [1, 0],
+  [0, -1],
+  [-1, 0],
+];
+const initialViruses = [];
+
+for (let i = 0; i < N; i++) {
+  for (let j = 0; j < N; j++) {
+    const virusType = map[i][j];
+    if (virusType > 0) initialViruses.push([virusType, 0, i, j]);
+  }
+}
+
+initialViruses.sort((a, b) => a[0] - b[0]);
+
+const queue = new Queue();
+
+for (const virus of initialViruses) {
+  queue.push(virus);
+}
+
+while (queue.size) {
+  const [virusType, time, x, y] = queue.shift();
+
+  if (time >= S) break;
+
+  for (const [dx, dy] of directions) {
+    const nx = x + dx;
+    const ny = y + dy;
+
+    if (nx < 0 || nx >= N || ny < 0 || ny >= N || map[nx][ny] > 0) continue;
+
+    map[nx][ny] = virusType;
+    queue.push([virusType, time + 1, nx, ny]);
+  }
+}
+
+console.log(map[X - 1][Y - 1]);


### PR DESCRIPTION
## [18405] 경쟁적 전염: bfs (1시간 27분)

### 문제에 대한 한줄 요약
각 바이러스를 순서에 맞춰 bfs를 돌리고 (X, Y) 좌표의 값을 출력하면 됩니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 3분
- 2단계 (알고리즘 선택): 1분
- 3단계 (구현 및 테스트): 1시간
- 4단계 (디버깅 및 제출): 23분

### 느낀점
일단 처음엔 역으로 (X, Y) 좌표에서 bfs를 돌려 먼저 닿는 바이러스를 구하는 로직으로 구현했지만 틀려서 문제에서 주어진대로 바이러스를 순서대로 시뮬레이션 하는 방향으로 바꿨습니다.

그 다음으론 각 바이러스의 타입 마다 Queue를 만들어서 바이러스의 순서대로 bfs를 돌리는 로직으로 구현했는데 실패했습니다.

이후에 ai의 도움을 받아 힌트를 얻었는데 하나의 큐에 [virusType, time, x, y] 의 형태로 저장해 bfs를 돌리는 방식이였습니다.
이전까진 S의 크기만큼 bfs를 돌리도록 구현했었는데 배열에 시간을 넣어서 체크하는 방식을 생각하지 못했습니다.

처음엔 정답이 이해가 잘 안갔는데 계속 생각해보니까 어느정도 이해되는거 같습니다.
구현하기 쉬울줄 알았는데 제가 생각했던 로직이랑 정답이랑 달라서 좀 어려웠던 거 같습니다.