### PR TITLE
PJH - [2877] 4와 7: 구현, 비트연산 (1시간 7분)

### DIFF
--- a/PJH/baekjoon/2877.js
+++ b/PJH/baekjoon/2877.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const K = Number(fs.readFileSync("input.txt").toString().trim()); // local 파일
+// const K = Number(fs.readFileSync(0, "utf-8").toString().trim()); // 문제 제출 시
+
+let length = 1;
+let count = 2;
+
+while (K > count) {
+  length++;
+  count += 2 ** length;
+}
+
+const prevCount = (1 << length) - 2;
+const index = K - prevCount - 1;
+
+const bit = index.toString(2).padStart(length, "0");
+
+console.log(
+  bit
+    .split("")
+    .map((n) => (n === "1" ? "7" : "4"))
+    .join("")
+);


### PR DESCRIPTION
## [2877] 4와 7: 구현 (1시간 7분)

### 문제에 대한 한줄 요약
4와 7로 이루어진 K번째 작은 수를 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 1분
- 2단계 (알고리즘 선택): 13분
- 3단계 (구현 및 테스트): 40분
- 4단계 (디버깅 및 제출): 13분

### 느낀점
먼저 답이 될 수 있는 4와 7로 이루어진 수를 작은 순서대로 구해봤습니다.
```
1번 4
2번 7
3번 44
4번 47
5번 74
6번 77
7번 444
8번 447
9번 474
10번 477
11번 744
12번 747
13번 774
14번 777
15번 4444
...
```
위 숫자들이 차례대로 커지는 것을 보고 2진수와 비슷하여 비트연산을 이용하면 문제를 풀 수 있겠다고 생각했습니다.

가장 먼저 눈에보이는 규칙적인 부분이 숫자의 길이였고, 길이를 구하는 방법은 생각보다 간단했습니다.
위 숫자들의 길이 규칙을 살펴보면 처음 길이 `1`부터 시작해 같은 길이를 가지는 수의 개수가 `2, 4, 8 ...` 이렇게 2의 제곱으로 늘어난다는 것을 확인했고, 아래처럼 반복문을 돌려서 K번째의 수가 얼마만큼의 길이를 가지는지 구했습니다.
```
let length = 1;
let count = 2;

while (K > count) {
  length++;
  count += 2 ** length;
}
```
초기 길이(length)는 1, 초기 숫자들의 개수(count)는 2로 선언했습니다. (길이가 1인 수, 즉 `4, 7`은 계산하지 않아도 되므로 초기값으로 선언)

그 다음 이전까지 나왔던 숫자들의 개수를 구합니다.
```
const prevCount = (1 << length) - 2;
```
앞에서 확인한 것 처럼 같은 길이를 가지는 수의 개수가 2의 제곱으로 늘어나므로 왼쪽 시프트(<<)를 통해 length번 제곱해줍니다.

아래 코드를 통해 K번째의 수가 같은 길이를 가지는 수 중에서 몇번째인지 인덱스를 구합니다.
```
const index = K - prevCount - 1;
```

마지막으로 10진수 index를 2진수로 변환한 후 length 만큼 앞에 '0'을 붙이고, '1'이면 7로, '0'이면 4로 변환하여 출력했습니다.

생각했던 알고리즘은 맞았으나 비트를 활용하는 방식이 익숙하지 않아 시간이 오래 걸렸던 것 같습니다.