### PR TITLE
PJH - [10472] 십자뒤집기: bfs (1시간 40분)

### DIFF
--- a/PJH/baekjoon/10472.js
+++ b/PJH/baekjoon/10472.js
@@ -1,0 +1,110 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+class Node {
+  constructor(data) {
+    this.data = data;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.front = null;
+    this.rear = null;
+    this.size = 0;
+  }
+
+  push(data) {
+    const newNode = new Node(data);
+
+    if (this.size === 0) {
+      this.front = newNode;
+      this.rear = newNode;
+    } else {
+      this.rear.next = newNode;
+      this.rear = newNode;
+    }
+
+    this.size++;
+  }
+
+  shift() {
+    if (this.size === 0) return null;
+
+    const data = this.front.data;
+
+    this.front = this.front.next;
+    this.size--;
+
+    return data;
+  }
+}
+
+function bfs(target) {
+  const queue = new Queue();
+  const initial = Array.from({ length: MAX }, () => Array(MAX).fill("."));
+  const set = new Set([serialize(initial)]);
+
+  queue.push([initial, 0]);
+
+  while (queue.size) {
+    const [board, count] = queue.shift();
+
+    if (serialize(board) === serialize(target)) return count;
+
+    for (let i = 0; i < MAX; i++) {
+      for (let j = 0; j < MAX; j++) {
+        const newBoard = copyBoard(board);
+        clickCell(newBoard, i, j);
+        const key = serialize(newBoard);
+
+        if (!set.has(key)) {
+          set.add(key);
+          queue.push([newBoard, count + 1]);
+        }
+      }
+    }
+  }
+
+  return -1;
+}
+
+function serialize(board) {
+  return board.map((row) => row.join("")).join("");
+}
+
+function copyBoard(board) {
+  return board.map((row) => [...row]);
+}
+
+function clickCell(board, x, y) {
+  for (const [dx, dy] of directions) {
+    const nx = x + dx;
+    const ny = y + dy;
+
+    if (nx < 0 || nx >= MAX || ny < 0 || ny >= MAX) continue;
+
+    board[nx][ny] = board[nx][ny] === "*" ? "." : "*";
+  }
+}
+
+const P = Number(input[0]);
+const directions = [
+  [0, 0],
+  [0, 1],
+  [1, 0],
+  [0, -1],
+  [-1, 0],
+];
+const MAX = 3;
+const result = [];
+let index = 1;
+
+for (let i = 0; i < P; i++) {
+  const target = input.slice(index, (index += MAX)).map((row) => row.split(""));
+  result.push(bfs(target));
+}
+
+console.log(result.join("\n"));


### PR DESCRIPTION
## [10472] 십자뒤집기: bfs (1시간 40분)

### 문제에 대한 한줄 요약
(3x3)인 흰색 보드를 입력으로 주어진 보드로 만들려고 할 때 필요한 최소 클릭 횟수를 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 6분
- 2단계 (알고리즘 선택): 28분
- 3단계 (구현 및 테스트): 1시간
- 4단계 (디버깅 및 제출): 6분

### 느낀점
처음 문제를 보고 생각했던 알고리즘
```
(0, 0) 부터 (2, 2) 까지 차례대로 칸을 확정짓는다.
먼저 입력으로 주어지는 (0, 0)이 검은색이라면 이 칸을 검은색으로 확정짓기 위해선 그 칸 혹은 인접한 칸을 클릭해야 한다.
클릭할 수 있는 칸을 클릭하는 경우를 나누어 큐에 넣는다.
큐에 넣을 땐 [(클릭하여 바뀐 상태의 2차원 보드), (클릭한 횟수), (확정지은 칸들의 배열)] 와 같은 형태로 넣는다.
```
이렇게 칸을 하나씩 확정지어 가면서 가장 작은 카운트로 입력으로 주어진 보드와 같은 경우를 찾는 방식으로 구현하려고 했습니다.
그런데 구현하다 보니 너무 복잡해서 구현하다 결국 gpt한테 도움을 요청했습니다.

gpt가 추천한 방식은 어차피 보드 크기가 3x3 이기 때문에 완탐으로도 충분히 풀린다고 하면서 bfs에서 단순히 모든 칸을 클릭 or 클릭하지 않는 경우를 탐색하라고 했습니다.

클릭할 때 마다 깊은 복사를 이용해서 클릭한 결과가 이전에 나왔던 결과인지 확인하고 나오지 않았다면 다시 큐에 새 보드를 넣어 모든 경우를 탐색했습니다.

사실 지금도 100% 이해되지 않네요.