### PR TITLE
PJH - [프로그래머스, 49191] 순위: dfs (44분)

### DIFF
--- a/PJH/programmers/49191.js
+++ b/PJH/programmers/49191.js
@@ -1,0 +1,38 @@
+function solution(n, results) {
+    const graph = Array.from({ length: n + 1 }, () => []);
+    const reverseGraph = Array.from({ length: n + 1 }, () => []);
+    let answer = 0;
+    
+    for (const [a, b] of results) {
+        graph[a].push(b);
+        reverseGraph[b].push(a);
+    }
+    
+    function dfs(start, graph) {
+        const visited = Array(n + 1).fill(false);
+        let count = 0;
+        
+        function traverse(node) {
+            for (const next of graph[node]) {
+                if (visited[next]) continue;
+                
+                count++;
+                visited[next] = true;
+                traverse(next);
+            }
+        }
+        
+        traverse(start);
+        
+        return count;
+    }
+    
+    for (let i = 1; i <= n; i++) {
+        const winCount = dfs(i, graph);
+        const loseCount = dfs(i, reverseGraph);
+        
+        if (winCount + loseCount === n - 1) answer++;
+    }
+    
+    return answer;
+}


### PR DESCRIPTION
## PJH - [프로그래머스, 49191] 순위: dfs (44분)

### 문제에 대한 한줄 요약
주어진 경기 결과를 통해 순위를 확정할 수 있는 선수의 수를 계산하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 3분
- 2단계 (알고리즘 선택): 1분
- 3단계 (구현 및 테스트): 39분
- 4단계 (디버깅 및 제출): 1분

### 느낀점
먼저 예제 입력으로 주어진 경기 결과를 그래프로 표현해봤습니다.
<img width="332" height="314" alt="스크린샷 2025-08-20 오후 5 02 28" src="https://github.com/user-attachments/assets/6da69850-54cb-4601-8959-06b2f36671e5" />

2번과 5번 선수가 순위를 확정할 수 있다고 설명해주고 있는데
먼저 2번 선수를 보면 이길 수 있는 선수가 5번 1명이고, 2번 선수를 이길 수 있는 선수가 1번, 3번, 4번 3명으로 총 4명 입니다.
<img width="312" height="290" alt="스크린샷 2025-08-20 오후 5 05 03" src="https://github.com/user-attachments/assets/1a840108-fe39-48ce-ac8b-76a74443a384" />

마찬가지로 5번 선수를 보면 5번 선수를 이길 수 있는 선수가 1번, 2번, 3번, 4번 총 4명 입니다.

즉, 특정 선수가 이길 수 있는 선수의 수와 질 수 있는 선수의 수의 합이 `n - 1` 이라면 그 선수의 순위를 확정할 수 있다고 볼 수 있습니다.

이를 통해 방향 그래프를 2개(정방향, 역방향) 선언하여 dfs를 돌려 이길 수 있는 선수의 수와 질 수 있는 선수의 수를 구했습니다.

문제 풀이법 자체는 빠르게 생각해 낼 수 있었지만, 프로그래머스에서 푸는 방식이 익숙치 않아서 시간이 오래 걸렸던 것 같습니다.
앞으로 프로그래머스에서도 문제를 많이 풀어보면서 익숙해 질 필요가 있겠네요.