### PR TITLE
PJH - [백준, 2304] 창고 다각형: 구현 (54분)

### DIFF
--- a/PJH/baekjoon/2304.js
+++ b/PJH/baekjoon/2304.js
@@ -1,0 +1,42 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+const N = Number(input[0]);
+const pillar = input
+  .slice(1)
+  .map((row) => row.split(" ").map(Number))
+  .sort((a, b) => a[0] - b[0]);
+const lastIndex = pillar[N - 1][0];
+let max = 0;
+let leftMaxIndex, rightMaxIndex;
+
+const map = Array(lastIndex + 1).fill(0);
+
+for (const [L, H] of pillar) {
+  if (H > max) {
+    max = H;
+    leftMaxIndex = L;
+    rightMaxIndex = L;
+  } else if (H === max) rightMaxIndex = L;
+
+  map[L] = H;
+}
+
+let currentMax = 0;
+let leftArea = 0;
+let rightArea = 0;
+
+for (let i = 1; i < leftMaxIndex; i++) {
+  if (map[i] > currentMax) currentMax = map[i];
+  leftArea += currentMax;
+}
+
+currentMax = 0;
+
+for (let i = lastIndex; i > rightMaxIndex; i--) {
+  if (map[i] > currentMax) currentMax = map[i];
+  rightArea += currentMax;
+}
+
+console.log(leftArea + rightArea + (rightMaxIndex - leftMaxIndex + 1) * max);


### PR DESCRIPTION
## PJH - [백준, 2304] 창고 다각형: 구현 (54분)

### 문제에 대한 한줄 요약
주어진 N개의 기둥을 이용해서 조건에 맞게 제작 가능한 창고 면적의 최소값을 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 4분
- 2단계 (알고리즘 선택): 20분
- 3단계 (구현 및 테스트): 23분
- 4단계 (디버깅 및 제출): 5분

### 느낀점
처음에 문제를 읽고 스택을 사용하여 풀려고 헀습니다만, 스택을 사용한 알고리즘을 생각하니 조건에 맞게 구현하는 방법이 잘 생각나지 않았습니다.
계속 생각해보다 도저히 해결법이 떠오르지 않아 gpt에 알고리즘 힌트를 물어봤고 아래와 같은 답변을 받을 수 있었습니다.

<img width="776" height="230" alt="스크린샷 2025-08-27 오전 11 37 32" src="https://github.com/user-attachments/assets/d5fd3e83-b38d-43c9-9826-07119f5825e4" />

이 아이디어의 핵심은 가장 높은 기둥을 선택하고, 기둥의 좌측과 우측을 따로 계산하여 나중에 합하는 방식을 사용합니다.
문제에서 주어진 5번 조건을 보면 '지붕의 어떤 부분도 오목하게 들어가면 안된다' 라고 나와있으므로 지붕의 모양은 산 모양으로만 설치가 가능하다는 것을 생각할 수 있었습니다.

산 모양으로만 설치가 가능하므로 자연스럽게 가장 높은 기둥의 좌측은 점점 올라가는 형태로 설치될 것이고,
우측은 점점 내려가는 형태로 설치될 것 입니다.

즉, 좌측에선 정방향으로 순회하며 각 칸을 지금까지 나온 최대 높이로 채우고,
우측에선 역방향으로 순회하며 마찬가지로 각 칸을 지금까지 나온 최대 높이로 채우는 알고리즘을 사용할 수 있습니다.

가장 높은 기둥이 여러개일 수 있으므로 가장 왼쪽의 최대 높이를 가지는 위치를 `leftMaxIndex`,
가장 오른쪽의 최대 높이를 가지는 위치를 `rightMaxIndex` 로 선언하여 각 위치에서 좌측과 우측의 면적을 계산하고,
최대 높이 사이의 공간은 `(rightMaxIndex - leftMaxIndex + 1) * 최대 높이` 로 구했습니다.

힌트를 보기 전에 중간에 최대값을 찾고 왼쪽 오른쪽을 나누어서 계산하는 방식을 떠올리긴 했었는데 힌트 알고리즘과는 약간 차이가 있었습니다.
그래도 해결법에 가깝게 생각한건 좋았네요. 좀 더 다양한 문제를 풀어보며 생각의 창을 넓혀가면 좋을 것 같다고 느꼈습니다.