### PR TITLE
PJH - [백준, 13164] 행복 유치원: 그리디 (1시간 9분)

### DIFF
--- a/PJH/baekjoon/13164.js
+++ b/PJH/baekjoon/13164.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+const [N, K] = input[0].split(" ").map(Number);
+const children = input[1].split(" ").map(Number);
+const diff = [];
+
+for (let i = 0; i < N - 1; i++) {
+  diff.push(Math.abs(children[i] - children[i + 1]));
+}
+
+diff.sort((a, b) => b - a);
+
+console.log(diff.slice(K - 1).reduce((sum, n) => (sum += n), 0));


### PR DESCRIPTION
## PJH - [백준, 13164] 행복 유치원: 그리디 (1시간 9분)

### 문제에 대한 한줄 요약
각 조에서 가장 작은 원생과 가장 큰 원생의 키 차이가 최소가 되도록 하는 K개의 조로 나누는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 3분
- 2단계 (알고리즘 선택): 41분
- 3단계 (구현 및 테스트): 23분
- 4단계 (디버깅 및 제출): 2분

### 느낀점
처음 문제를 접근할 때는 문제에 설명된 대로 조를 묶는 방법에 대해서 많이 고민했었습니다.
결국 가장 작은 조원과 가장 큰 조원의 키 차이가 최소가 되어야 하므로 모든 아이들에 대해서 주변에 인접한 아이와의 키 차이를 구해봤습니다.

인접한 아이끼리만 키 차이를 구한 이유는 이미 입력으로 주어지는 아이들의 키는 오름차순으로 정렬되어 있고, 조 내에서 최소값과 최대값이 크게 차이나면 안되기 때문에 무조건 키 순서가 연속된 아이들로 조를 편성하는 것이 유리하기 때문에 그렇습니다.

조를 묶을 때 K개의 조가 만들어지도록 해야 하고, 조 내에서 최소값과 최대값이 최선이 되도록 해야 하는데 이 조건을 반복문을 통한 편성 방식으로는 불가능하다고 생각했습니다.

여기서 조를 묶는다는 생각에서 발상의 전환을 통해 "가림막을 통해 조를 나눈다" 라고 생각해봤습니다.
3개의 조로 나눈다 라고 주어진다면 "2개의 가림막을 통해 조를 3등분 한다" 라고 생각할 수도 있습니다.

즉, N명의 키 차이의 개수는 `N - 1` 이고, K개의 조로 나누기 위해 `K - 1` 개의 가림막이 필요하다고 정의할 수 있습니다.

`K - 1` 개의 가림막이 필요하다면 키 차이가 가장 크게 나는 부분부터 가림막을 설치하면 최적의 해를 구할 수 있을 것입니다.

아이들을 노드로 보고, 키 차이를 간선으로 생각해볼 수도 있겠네요.
간선의 합이 최소가 되는 K개의 그래프로 나누는 방법을 생각해본다면 간선 '4'를 끊고, 간선 '2'를 끊는 방법이 최적일 것 입니다.
(남은 간선들의 합은 3)
<img width="432" height="199" alt="스크린샷 2025-09-01 오후 7 39 10" src="https://github.com/user-attachments/assets/20b98a66-1c4b-4b20-a91f-fd6482efc81e" />

만약 입력이 아래와 같이 주어진다면,
```
7 3
1 5 10 11 15 20 23
```

<img width="612" height="398" alt="스크린샷 2025-09-01 오후 7 44 43" src="https://github.com/user-attachments/assets/f142766b-d0e0-484a-9cde-8f563bd0350f" />

가장 키 차이가 많이 나는 5와 10 사이, 15와 20 사이에 가림막을 설치하여 조를 만들면 됩니다.

이 문제를 풀면서 확실히 그리디 문제는 "문제를 바라보는 관점" 이 중요하다고 느꼈습니다.