### PR TITLE
PJH - [백준, 2240] 자두나무: dp (1시간 6분)

### DIFF
--- a/PJH/baekjoon/2240.js
+++ b/PJH/baekjoon/2240.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+const [T, W] = input[0].split(" ").map(Number);
+const position = input.slice(1).map(Number);
+const dp = Array.from({ length: T }, () =>
+  Array.from({ length: 2 }, () => Array(W + 1).fill(0))
+);
+
+if (position[0] === 1) dp[0][0][0] = 1;
+else dp[0][1][1] = 1;
+
+for (let i = 1; i < T; i++) {
+  const droppedPosition = position[i];
+
+  for (let k = 0; k <= W; k++) {
+    if (k === 0) {
+      dp[i][0][k] = dp[i - 1][0][k] + (droppedPosition === 1 ? 1 : 0);
+    } else {
+      dp[i][0][k] =
+        Math.max(dp[i - 1][0][k], dp[i - 1][1][k - 1]) +
+        (droppedPosition === 1 ? 1 : 0);
+      dp[i][1][k] =
+        Math.max(dp[i - 1][1][k], dp[i - 1][0][k - 1]) +
+        (droppedPosition === 2 ? 1 : 0);
+    }
+  }
+}
+
+console.log(Math.max(...dp[T - 1].flat()));


### PR DESCRIPTION
## PJH - [백준, 2240] 자두나무: dp (1시간 6분)

### 문제에 대한 한줄 요약
W번 이하만 움직이며 두 자두나무 아래에서 얻을 수 있는 자두의 최대 개수를 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 3분
- 2단계 (알고리즘 선택): 10분
- 3단계 (구현 및 테스트): 48분
- 4단계 (디버깅 및 제출): 5분

### 느낀점
각 초에 가장 최선의 선택을 반복문을 사용하여 구하는 것은 시간이 너무 오래걸린다고 생각되어 dp 를 써야 겠다고 생각했습니다.
보통 dp는 메모이제이션을 사용하므로 dp 배열을 정의하는 것 부터 시작했습니다.

사실 이동 횟수에 제한이 없다면 아래처럼 쉽게 배열을 정의할 수 있습니다.
```
dp[i][j]
-> i초에 j번 나무 아래 있을 때 얻을 수 있는 자두의 최대 개수
```

해당 문제는 최대 이동 횟수 `W`가 조건에 포함되어 있으므로 해당 조건에 맞게 최선의 선택을 구할 필요가 있습니다.
아래는 조건 W를 포함한 dp 배열의 정의입니다.

```
dp[i][j][k]
i초에 j번 나무 아래 있을 때 얻을 수 있는 자두의 최대 개수 (k는 이동 횟수)
```

dp의 초기값은 아래와 같습니다.

```
if (position[0] === 1) dp[0][0][0] = 1;
else dp[0][1][1] = 1;
```

초기에는 0번 나무에 위치하고 있으므로 바로 다음에 1번 나무에서 자두가 떨어진다면 0초에 0번 이동하여 0번 나무 아래서 1개의 자두를 얻을 수 있습니다. (코드에선 인덱스 기준으로 관리해서 초랑 나무 번호가 0번부터 시작합니다.)
만약 1번 나무에서 자두가 떨어진다면 0초에 1번 이동하여 1번 나무 아래서 1개의 자두를 얻을 수 있습니다.

dp 점화식은 아래와 같습니다.

```
dp[i][0][k] = Math.max(dp[i - 1][0][k], dp[i - 1][1][k - 1]) + (droppedPosition === 1 ? 1 : 0);
dp[i][1][k] = Math.max(dp[i - 1][1][k], dp[i - 1][0][k - 1]) + (droppedPosition === 2 ? 1 : 0);
```

i초마다 자두가 떨어질 때 이렇게 생각해볼 수 있습니다.

1. i초에 0번 나무 아래에 있는 경우 (`dp[i][0][k]`)
- 가만히 있있을 경우: `i - 1`초에도 0번 나무 아래에 있었으므로 이동 횟수는 그대로 `k`입니다.
   - 이전값: `dp[i - 1][0][k]`
- 움직여서 온 경우: `i - 1`초에 1번 나무 아래에 있었고 이동하여 0번 나무 아래로 왔으므로 기존 이동 횟수는 `k - 1`이였고 이동하여 `k`가 됩니다.
   - 이전값: `dp[i - 1][1][k - 1]`

이를 위 점화식으로 바꿀 수 있고 i초에 1번 나무 아래에 있는 경우(`dp[i][1][k]`)도 같은 방식으로 구할 수 있습니다.

그리고 `k`가 0이라면 이전에 이동한 값이 `k - 1`이 될 수 없으므로 `dp[i][0][k]`에선 항상 `dp[i - 1][0][k]`을 선택해야 하므로 `k`가 0인 경우는 따로 식을 세워줬습니다. (`dp[i][1][k]`일 때의 점화식이 없는 이유는 `k`가 0일 때는 1번 나무로 이동한다는 가정이 성립하지 않기 때문입니다.)

dp 배열을 정의하는 것 까지는 어렵지 않았는데 이동 횟수에 제한이 있다는 점에서 점화식을 생각해내는데 시간이 좀 걸렸습니다.