### PR TITLE
PJH - [백준, 2531] 회전 초밥: 슬라이딩 윈도우 (57분)

### DIFF
--- a/PJH/baekjoon/2531.js
+++ b/PJH/baekjoon/2531.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+const [N, d, k, c] = input[0].split(" ").map(Number);
+const sushi = input.slice(1).map(Number);
+const eats = Array(d + 1).fill(0);
+let count = 0;
+
+for (let i = 0; i < k; i++) {
+  if (eats[sushi[i]] === 0) count++;
+  eats[sushi[i]]++;
+}
+
+let maxCount = count;
+
+if (eats[c] === 0) maxCount++;
+
+for (let front = 0; front < N; front++) {
+  let rear = (front + k) % N;
+
+  eats[sushi[front]]--;
+  if (eats[sushi[front]] === 0) count--;
+
+  if (eats[sushi[rear]] === 0) count++;
+  eats[sushi[rear]]++;
+
+  maxCount = Math.max(maxCount, count + (eats[c] === 0 ? 1 : 0));
+}
+
+console.log(maxCount);


### PR DESCRIPTION
## PJH - [백준, 2531] 회전 초밥: 슬라이딩 윈도우 (57분)

### 문제에 대한 한줄 요약
k개의 접시를 연속해서 먹을 때, 먹을 수 있는 초밥 종류의 최대값을 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 5분
- 2단계 (알고리즘 선택): 4분
- 3단계 (구현 및 테스트): 40분
- 4단계 (디버깅 및 제출): 8분

### 느낀점
일단 k개의 접시를 연속해서 먹는 경우를 모두 구하고, 각 경우에서 먹는 초밥의 종류를 구해야 합니다. 이후에 초밥 종류의 최대값이 문제의 정답입니다.

가장 간단하게 생각해봤을 땐 slice 함수를 이용해서 주어진 입력에서 모든 경우의 수를 배열로 자르는 방식이 있습니다.
논리적으론 가장 간단하지만 새로 배열을 만들어야 하고 새로 만드는 각 배열마다 종류의 수를 구해야 한다는 점에서 시간초과가 날 수 있습니다.

그 다음으로 생각한 방법은 배열을 하나 만들어서 k개의 접시를 연속해서 먹는 경우를 구하는 방식입니다.
`[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]` 처럼 배열을 하나 만들고 순서대로 shift()와 push()를 이용하는건데 이 역시 배열이 만들어질 때 마다 중복을 제거하고 종류의 수를 구해야 하므로 비효율적이였습니다.

마지막으로 생각한 방식은 초밥을 먹은 횟수를 배열 `eats`에 저장하는 방식입니다.
길이가 `d`인 배열을 만들고 각 인덱스에 저장된 값는 각 초밥을 먹은 횟수를 저장합니다.

이 방법을 사용하면 0인 초밥은 한번도 먹지 않았다는 의미이고 1 이상인 초밥은 먹었다는 의미가 되기 때문에 중복을 제거하지 않아도 종류의 수를 쉽게 확인할 수 있습니다.
`front`와 `rear` 포인터를 이용해서 `front`에 걸린 초밥은 `eats`배열에서 횟수를 하나 빼고 값이 0이 되면 현재 초밥 종류를 저장하는 `count`에서 -1 합니다.
`rear`에 걸린 초밥의 값이 0 이라면 한번도 먹지 않았다는 의미이므로 `count`를 +1 합니다.
이후에 `eats` 배열에서 횟수를 하나 더합니다.

현재 케이스에서 쿠폰으로 먹을 수 있는 c 초밥을 먹지 않았다면 무료로 하나 더 먹을 수 있으므로 `count`를 +1 합니다.

배열에 각 숫자가 나온 횟수를 저장하는 방식이 새롭다고 느꼈습니다. 처음엔 d값이 왜 필요한가 했더니 다 이유가 있었네요.