### PR TITLE
PJH - [백준, 20364] 부동산 다툼: 이진 트리 (27분)

### DIFF
--- a/PJH/baekjoon/20364.js
+++ b/PJH/baekjoon/20364.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+const [N, Q] = input[0].split(" ").map(Number);
+const land = Array(N + 1).fill(false);
+const ducks = input.slice(1).map(Number);
+const result = [];
+
+for (let i = 0; i < Q; i++) {
+  let current = ducks[i];
+  let collisionPoint = land[current] ? current : 0;
+
+  while (current !== 1) {
+    const parent = Math.floor(current / 2);
+
+    if (land[parent]) collisionPoint = parent;
+    current = parent;
+  }
+
+  if (collisionPoint === 0) land[ducks[i]] = true;
+  result.push(collisionPoint);
+}
+
+console.log(result.join("\n"));


### PR DESCRIPTION
## PJH - [백준, 20364] 부동산 다툼: 이진 트리 (27분)

### 문제에 대한 한줄 요약
각각의 오리가 원하는 땅을 가질 수 있는지 판별하고 가질 수 없다면 처음 마주치는 점유된 땅의 번호를 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 2분
- 2단계 (알고리즘 선택): 1분
- 3단계 (구현 및 테스트): 19분
- 4단계 (디버깅 및 제출): 5분

### 느낀점
간단하게 노드 1에서부터 시작해서 트리를 타고 내려가면서 땅을 나눌 수 있다면 좋겠지만 원하는 땅이 왼쪽 자식 노드에 있는지, 오른쪽 자식 노드에 있는지 판별하기 어렵다고 봤습니다.
그래서 1번 노드부터 시작하는 것이 아니라 원하는 땅에서부터 시작하여 역으로 트리를 타고 올라가면서 부모노드가 이미 다른 오리에게 점유되었는지 확인하는 방식으로 구현했습니다.

첫번째 제출에서 1%에서 실패가 떴었는데 부모 노드의 점유여부만 체크했던 것이 문제였습니다.
처음에 현재 노드도 점유되었는지 체크하도록 수정했더니 정답처리되었네요.

이진 트리의 특성에 대해서 알 수 있는 문제였습니다.