### PR TITLE
PJH - [백준, 1706] 크로스워드: 구현, 문자열 (27분)

### DIFF
--- a/PJH/baekjoon/1706.js
+++ b/PJH/baekjoon/1706.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+const [R, C] = input[0].split(" ").map(Number);
+const puzzle = input.slice(1).map((row) => row.split(""));
+const words = [];
+
+for (let i = 0; i < R; i++) {
+  let rowString = "";
+
+  for (let j = 0; j < C; j++) {
+    rowString += puzzle[i][j];
+  }
+
+  const rowWords = rowString.split("#").filter((word) => word.length > 1);
+
+  for (const word of rowWords) {
+    words.push(word);
+  }
+}
+
+for (let i = 0; i < C; i++) {
+  let colString = "";
+
+  for (let j = 0; j < R; j++) {
+    colString += puzzle[j][i];
+  }
+
+  const colWords = colString.split("#").filter((word) => word.length > 1);
+
+  for (const word of colWords) {
+    words.push(word);
+  }
+}
+
+console.log(words.sort()[0]);


### PR DESCRIPTION
## PJH - [백준, 1706] 크로스워드: 구현, 문자열 (27분)

### 문제에 대한 한줄 요약
크로스워드 퍼즐에서 단어를 모두 찾고, 사전순으로 가장 처음의 단어를 출력하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 1분
- 2단계 (알고리즘 선택): 1분
- 3단계 (구현 및 테스트): 24분
- 4단계 (디버깅 및 제출): 1분

### 느낀점
이번 문제는 문제에서 주어진 조건대로만 구현하면 쉽게 풀 수 있는 문제였습니다.

가로와 세로 각각 따로 반복하며 한 줄(한 문자열)을 만듭니다.
`#`은 빈 칸이므로 `split()` 함수를 이용해 문자열을 자르고, 길이가 2 이상인 단어만 필터링했습니다.
이후에 모든 단어들을 정렬하고 첫 단어를 출력합니다.

구현 중에 반복문 하나만 사용해서 가로와 세로 문자열을 한번에 구할 수 있을까 생각해봤는데 가로와 세로의 크기가 서로 달라 그렇게는 구현이 불가능했습니다.