### PR TITLE
KSM - [백준, 1706] 크로스워드: 구현, 정렬 (66분)

### DIFF
--- a/KSM/baekjoon/1706.js
+++ b/KSM/baekjoon/1706.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const input = fs.readFileSync(0, "utf8").trim().split("\n");
+
+const [R, C] = input[0].split(" ").map(Number);
+const puzzle = input.slice(1);
+
+const horizontalWords = [];
+const verticalWords = [];
+
+for (let r = 0; r < R; r++) {
+  const row = puzzle[r];
+  const rowParts = row.split("#");
+
+  for (const word of rowParts) {
+    if (word.length >= 2) {
+      horizontalWords.push(word);
+    }
+  }
+}
+
+for (let c = 0; c < C; c++) {
+  let column = "";
+  for (let r = 0; r < R; r++) {
+    column += puzzle[r][c];
+  }
+
+  const colParts = column.split("#");
+  for (const word of colParts) {
+    if (word.length >= 2) {
+      verticalWords.push(word);
+    }
+  }
+}
+
+const allWords = [...horizontalWords, ...verticalWords];
+allWords.sort();
+console.log(allWords[0]);


### PR DESCRIPTION
## KSM - [백준, 1706] 크로스워드: 구현, 정렬 (66분)

### 문제에 대한 한줄 요약
가로, 세로 #을 기준으로 나뉜 2자리 수 이상의 단어 중 사전순으로 가장 앞에 있는 단어를 출력하는 문제
### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 6분
- 2단계 (알고리즘 선택): ㅡ
- 3단계 (구현 및 테스트): 60분
- 4단계 (디버깅 및 제출): ㅡ

### 느낀점

- 가로와 세로의 줄 수는 다를 수 있음. 정사각형 아님.
- #을 기준으로 나뉜 2 이상의 연속된 알파벳만 단어임.
- 가로 단어와 세로 단어를 각각 배열에 담은 뒤, 하나의 배열로 합쳐서 sort로 정렬 후 가장 첫번째에 있는 단어를 출력함. 
- const puzzle = input.slice(1);로 받아서 row는 배열이었지만, column은 ""으로 초기화하고, split("#")을 통해 각 행의 문자를 붙여서  배열로 바꿔 줌.

열 단위를 구현하니까 오랜만에 별 찍기가 생각났다.. 초심 찾기 문제 같은 기분. 