### PR TITLE
LSH - [백준, 14426] 접두사 찾기: 모름 (20분)

### DIFF
--- a/LSH/baekjoon/14000/14426-접두사-찾기.js
+++ b/LSH/baekjoon/14000/14426-접두사-찾기.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const input =
+  process.platform !== 'linux'
+    ? fs.readFileSync(`${__dirname}/../input.txt`).toString().trim().split('\n')
+    : fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+const [NM, ...arr] = input;
+const [N, M] = NM.split(' ');
+const stringArr = arr.slice(0, N);
+const substringArr = arr.slice(N, N + M);
+
+/**
+ * 문제 url: https://www.acmicpc.net/problem/14426
+ * 문제 이름: 접두사 찾기
+ * 시작 시각: 2025. 9. 9. 오후 2:01:38
+ * 1단계 (문제 이해 및 조건 분석): 4분
+ * 2단계 (알고리즘 선택): 0분
+ * 3단계 (구현 및 테스트): 13분
+ * 4단계 (디버깅 및 제출): 3분
+ */
+function main(strings, subStrings) {
+  const prefixStrSet = new Set();
+
+  for (const str of strings) {
+    for (let i = 1; i < str.length + 1; i += 1) {
+      prefixStrSet.add(str.slice(0, i));
+    }
+  }
+
+  let prefixCount = 0;
+
+  for (const subString of subStrings) {
+    prefixCount += Number(prefixStrSet.has(subString));
+  }
+
+  console.log(prefixCount);
+}
+
+main(stringArr, substringArr);

--- a/LSH/baekjoon/input.txt
+++ b/LSH/baekjoon/input.txt
@@ -1,3 +1,16 @@
-2 2
-00
-01
+5 10
+baekjoononlinejudge
+startlink
+codeplus
+sundaycoding
+codingsh
+baekjoon
+star
+start
+code
+sunday
+coding
+cod
+online
+judge
+plus


### PR DESCRIPTION
## LSH - [백준, 14426] 접두사 찾기: 모름 (20분)

### 문제에 대한 한줄 요약

여러 문자열 셋과 여러 접두사 후보 셋이 주어졌을 때 유효한 접두사의 개수를 찾는 문제

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석):  4분
- 2단계 (알고리즘 선택):  0분
- 3단계 (구현 및 테스트): 13분
- 4단계 (디버깅 및 제출): 3분

### 느낀점

1. 처음에 단순히 접두사 후보 셋이 문자열 셋의 startsWith인지 확인하여 풀려고 했으나 시간초과가 나는 현상이 있었음
2. 메모리가 1536MB로 꽤 크게 주어졌기 때문에 유일성을 보장하는 set 자료형을 활용하여 빠르게 유효한 접두사를 사용하여 해결