### PR TITLE
이석호 - [백준, 20207] 달력: 구현? (24분)

### DIFF
--- a/LSH/baekjoon/20000/20207-달력.js
+++ b/LSH/baekjoon/20000/20207-달력.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const input =
+  process.platform !== 'linux'
+    ? fs.readFileSync(`${__dirname}/../input.txt`).toString().trim().split('\n')
+    : fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+const [_, ...arr] = input;
+
+/**
+ * 문제 url: https://www.acmicpc.net/problem/20207
+ * 문제 이름: 달력
+ * 시작 시각: 2025. 9. 10. 오전 9:28:06
+ * 1단계 (문제 이해 및 조건 분석): 8분
+ * 2단계 (알고리즘 선택): 1분
+ * 3단계 (구현 및 테스트): 14분
+ * 4단계 (디버깅 및 제출): 1분
+ */
+function main(schedules) {
+  const promiseCountArr = new Array(367).fill(0);
+
+  for (const schedule of schedules) {
+    const [startDay, endDay] = schedule;
+
+    for (let i = startDay; i <= endDay; i += 1) {
+      promiseCountArr[i] += 1;
+    }
+  }
+
+  let coatedPaperArea = 0;
+  let maxPromiseCount = 0;
+  let continuousScheduleCount = 0;
+
+  for (const promiseCount of promiseCountArr) {
+    if (promiseCount === 0) {
+      coatedPaperArea += maxPromiseCount * continuousScheduleCount;
+      maxPromiseCount = 0;
+      continuousScheduleCount = 0;
+    } else {
+      continuousScheduleCount += 1;
+      maxPromiseCount = Math.max(maxPromiseCount, promiseCount);
+    }
+  }
+
+  console.log(coatedPaperArea);
+}
+
+main(
+  arr.map((el) => {
+    return el.split(' ').map(Number);
+  })
+);

--- a/LSH/baekjoon/input.txt
+++ b/LSH/baekjoon/input.txt
@@ -1,16 +1,6 @@
-5 10
-baekjoononlinejudge
-startlink
-codeplus
-sundaycoding
-codingsh
-baekjoon
-star
-start
-code
-sunday
-coding
-cod
-online
-judge
-plus
+5
+1 9
+8 9
+4 6
+3 4
+2 5


### PR DESCRIPTION
## 이석호 - [백준, 20207] 달력: 구현? (24분)

### 문제에 대한 한줄 요약

다수의 일정(시작일과 종료일이 있는)들을 일자별로 총 몇개의 일정이 있는지 정리하여 직사각형 형태로 만들어 총 면적을 구하는 문제

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 8분
- 2단계 (알고리즘 선택): 1분
- 3단계 (구현 및 테스트): 14분
- 4단계 (디버깅 및 제출): 1분

### 느낀점

처음에 문제 이해가 어려웠으나 문제 이해 후 총 개수만 구하면 되는 특성을 이용해 임의의 1년짜리 빈 일정 달력을 만든 뒤 카운팅하여 풀면 된다고 판단했는지 다행히 시간초과가 안남