### PR TITLE
add PR auto merge github actions delay

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,6 +26,7 @@ jobs:
                   pull_number: pr.number,
                   merge_method: "squash" // 필요에 따라 merge, rebase 가능
                 });
+                await new Promise((res) => setTimeout(res, 5000));
                 core.info(`✅ PR #${pr.number} merged`);
               } catch (error) {
                 core.warning(`⚠️ Could not merge PR #${pr.number}: ${error.message}`);


### PR DESCRIPTION
## Description

모든 PR이 main branch를 base로 바라보기 때문에
PR merge시점에 base branch 머지 검사 이전에
merge를 시도하다 실패하는 현상이 있기 때문에 딜레이를 추가
빠르게 머지되지 않아도 되기때문에 넉넉하게 5000ms로 지정