### PR TITLE
PJH - [백준, 2257] 화학식량: 스택 (36분)

### DIFF
--- a/PJH/baekjoon/12761.js
+++ b/PJH/baekjoon/12761.js
@@ -1,0 +1,79 @@
+const fs = require("fs");
+const [A, B, N, M] = fs
+  .readFileSync("input.txt")
+  .toString()
+  .trim()
+  .split(" ")
+  .map(Number); // local 파일
+// const [A, B, N, M] = fs.readFileSync(0, "utf-8").toString().trim().split(" ").map(Number); // 문제 제출 시
+
+class Node {
+  constructor(data) {
+    this.data = data;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.front = null;
+    this.rear = null;
+    this.size = 0;
+  }
+
+  push(data) {
+    const newNode = new Node(data);
+
+    if (this.size === 0) {
+      this.front = newNode;
+      this.rear = newNode;
+    } else {
+      this.rear.next = newNode;
+      this.rear = newNode;
+    }
+
+    this.size++;
+  }
+
+  shift() {
+    if (this.size === 0) return null;
+
+    const data = this.front.data;
+
+    this.front = this.front.next;
+    this.size--;
+
+    return data;
+  }
+}
+
+const queue = new Queue();
+const visited = Array(100001).fill(false);
+
+queue.push([N, 0]);
+
+while (queue.size) {
+  const [position, count] = queue.shift();
+  const nextCases = [
+    position + 1,
+    position - 1,
+    position + A,
+    position - A,
+    position + B,
+    position - B,
+    position * A,
+    position * B,
+  ];
+
+  if (position === M) {
+    console.log(count);
+    return;
+  }
+
+  for (const next of nextCases) {
+    if (next < 0 || next > 100000 || visited[next] === true) continue;
+
+    queue.push([next, count + 1]);
+    visited[next] = true;
+  }
+}

--- a/PJH/baekjoon/1455.js
+++ b/PJH/baekjoon/1455.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+const [N, M] = input[0].split(" ").map(Number);
+const coins = input.slice(1).map((row) => row.split("").map(Number));
+const dp = Array.from({ length: N + 1 }, () => Array(M + 1).fill(0));
+let count = 0;
+
+for (let i = N - 1; i >= 0; i--) {
+  for (let j = M - 1; j >= 0; j--) {
+    dp[i][j] = dp[i + 1][j] + dp[i][j + 1] - dp[i + 1][j + 1];
+
+    const currentCoin = (coins[i][j] + dp[i][j]) % 2;
+
+    if (currentCoin === 1) {
+      count++;
+      dp[i][j]++;
+    }
+  }
+}
+
+console.log(count);

--- a/PJH/baekjoon/2257.js
+++ b/PJH/baekjoon/2257.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split(""); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split(""); // 문제 제출 시
+
+function getNum(char) {
+  return char === "H" ? 1 : char === "C" ? 12 : 16;
+}
+
+const stack = [];
+
+for (let i = 0; i < input.length; i++) {
+  const char = input[i];
+
+  if (isNaN(char)) {
+    if (char === "(") stack.push(0);
+    else if (char === ")") {
+      let sum = 0;
+
+      while (true) {
+        const num = stack.pop();
+        if (num === 0) break;
+
+        sum += num;
+      }
+
+      stack.push(sum);
+    } else stack.push(getNum(char));
+  } else stack.push(stack.pop() * Number(char));
+}
+
+console.log(stack.reduce((sum, n) => (sum += n), 0));

--- a/PJH/baekjoon/4811.js
+++ b/PJH/baekjoon/4811.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const input = fs
+  .readFileSync("input.txt")
+  .toString()
+  .trim()
+  .split("\n")
+  .map(Number); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n").map(Number); // 문제 제출 시
+
+function solve(N) {
+  const dp = Array.from({ length: N + 1 }, () => Array(N + 1).fill(0n));
+
+  function dfs(w, h) {
+    if (w === 0) return 1n;
+    if (dp[w][h] !== 0n) return dp[w][h];
+
+    let count = 0n;
+
+    count += dfs(w - 1, h + 1);
+
+    if (h > 0) count += dfs(w, h - 1);
+
+    dp[w][h] = count;
+    return count;
+  }
+
+  return dfs(N, 0);
+}
+
+const result = [];
+
+for (const N of input) {
+  if (N === 0) break;
+
+  result.push(solve(N).toString());
+}
+
+console.log(result.join("\n"));


### PR DESCRIPTION
## PJH - [백준, 2257] 화학식량: 스택 (36분)

### 문제에 대한 한줄 요약
스택을 사용하여 입력으로 주어진 화학식을 계산하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 3분
- 2단계 (알고리즘 선택): 12분
- 3단계 (구현 및 테스트): 20분
- 4단계 (디버깅 및 제출): 1분

### 느낀점
알파벳이 나온다면 더하기, 숫자가 나온다면 앞 수와 곱셈한 후에 다시 스택에 넣으면 되기 때문에 이 부분은 크게 어렵지 않았습니다.
알파벳을 숫자로 바꾸고 덧셈이 기본 연산이기 때문에 스택에 곱셈만 미리 계산해서 넣고, 나중에 모두 더하면 되겠다고 생각했습니다.

괄호를 어떻게 처리할 건지를 좀 오래 고민했습니다.
재귀함수로 구현해야 하나, 스택을 새로 만들어야 하나, 변수를 새로 만들어야 하나 고민하다
여는 괄호가 나오면 괄호를 의미하는 수(0)를 스택에 넣고, 닫는 괄호가 나오면 0까지 모두 더하는 로직으로 구현에 성공했습니다.

괄호에 대한 처리방법을 잘 생각해야 했던 문제였습니다.