### PR TITLE
PJH - [백준, 2302] 극장 좌석: dp (34분)

### DIFF
--- a/PJH/baekjoon/2302.js
+++ b/PJH/baekjoon/2302.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const [N, M, ...VIP] = fs
+  .readFileSync("input.txt")
+  .toString()
+  .trim()
+  .split("\n")
+  .map(Number); // local 파일
+// const [N, M, ...VIP] = fs.readFileSync(0, "utf-8").toString().trim().split("\n").map(Number); // 문제 제출 시
+
+const seat = Array(N + 1).fill(true);
+const dp = Array(N + 1).fill(0);
+const rows = [];
+
+for (let i = 0; i < M; i++) {
+  seat[VIP[i]] = false;
+}
+
+dp[0] = 1;
+dp[1] = 1;
+
+for (let i = 2; i <= N; i++) {
+  dp[i] = dp[i - 2] + dp[i - 1];
+}
+
+let count = 0;
+
+for (let i = 1; i <= N; i++) {
+  if (seat[i]) count++;
+  else {
+    if (count > 0) rows.push(count);
+    count = 0;
+  }
+}
+
+rows.push(count);
+
+console.log(rows.reduce((result, n) => (result *= dp[n]), 1) || 1);


### PR DESCRIPTION
## PJH - [백준, 2302] 극장 좌석: dp (34분)

### 문제에 대한 한줄 요약
연속된 일반 좌석의 수를 각각 구하고 연속 좌석에서 나올 수 있는 경우의 수를 곱해주면 된다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 2분
- 2단계 (알고리즘 선택): 9분
- 3단계 (구현 및 테스트): 20분
- 4단계 (디버깅 및 제출): 3분

### 느낀점
처음에는 백트래킹 문제라고 생각했으나, 예제 그림을 보고 굳이 모든 경우를 탐색하지 않아도 되겠다고 생각했습니다.
옆자리로 바꿔 앉을 수 있는 일반 좌석이 2개가 붙어있으면 경우의 수는 2,
3개가 붙어있으면 경우의 수는 3 이고, 경우의 수를 모두 곱하면 답이 나온다는 규칙을 찾았습니다.

5개가 붙어있는 경우까지 직접 계산해보면 규칙을 찾을 수 있는데, dp로 간단하게 경우의 수를 구할 수 있습니다.