### PR TITLE
PJH - [백준, 6236] 용돈 관리: 이분 탐색 (45분)

### DIFF
--- a/PJH/baekjoon/6236.js
+++ b/PJH/baekjoon/6236.js
@@ -1,0 +1,42 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+function getWithdrawCount(amount) {
+  let current = amount;
+  let count = 1;
+
+  for (let i = 0; i < N; i++) {
+    if (current < dailyAmount[i]) {
+      current = amount;
+      count++;
+    }
+
+    current -= dailyAmount[i];
+  }
+
+  return count;
+}
+
+function binarySearch(start, end) {
+  let answer = 0;
+
+  while (start <= end) {
+    const mid = Math.floor((start + end) / 2);
+    const count = getWithdrawCount(mid);
+
+    if (count <= M) {
+      answer = mid;
+      end = mid - 1;
+    } else start = mid + 1;
+  }
+
+  return answer;
+}
+
+const [N, M] = input[0].split(" ").map(Number);
+const dailyAmount = input.slice(1).map(Number);
+const max = Math.max(...dailyAmount);
+const sum = dailyAmount.reduce((sum, n) => (sum += n), 0);
+
+console.log(binarySearch(max, sum));


### PR DESCRIPTION
## PJH - [백준, 6236] 용돈 관리: 이분 탐색 (45분)

### 문제에 대한 한줄 요약
이분 탐색을 통해서 M번만 돈을 뽑을 때 금액 K의 최소값을 구하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 6분
- 2단계 (알고리즘 선택): 8분
- 3단계 (구현 및 테스트): 30분
- 4단계 (디버깅 및 제출): 1분

### 느낀점
"특정 금액 K를 임의로 선택하고, 그 금액을 M번만 뽑아서 N일 동안 부족함 없이 쓸 수 있나?" 에 대해 구하는 문제이므로 매개 변수 탐색 즉, 이분 탐색을 통해 해결 할 수 있을 것이라고 생각했습니다.

일단 각 날에 사용할 금액 이상을 인출할 수 있어야 부족함 없이 사용할 수 있으므로 최소값은 "각 날에 사용할 금액들 중 최대값"이 되고,
인출금액의 최대값은 한번만 인출해도 모든 날에 사용이 가능해야 하므로 "각 날에 사용할 금액들의 합"이 됩니다.
(예제1에선 1901 이상을 인출하면 한번만 인출해도 모든 날에 사용 가능하지만, 문제에선 인출 가능한 값 중 최소값을 구해야 하므로 그 이상은 계산하지 않아도 됩니다.)

이 후, `binarySearch()`함수 내에서 `mid`금액만큼 인출한다고 가정했을 때 인출해야 할 횟수를 `getWithdrawCount()`함수를 이용해 구하고, `count`의 값에 따라 범위를 좁혀가면서 답을 찾습니다.

`count`의 값이 M보다 작거나 같으면 `mid`금액이 답보다 크거나 같다는 것을 의미하므로 `answer`에 `end`를 저장하고 `end = mid - 1`을 통해 다음에 계산할 범위를 `mid`금액보다 작게 좁힙니다.
`count`의 값이 M보다 크다면 `mid`금액이 답보다 작다는 것을 의미하므로 `start = mid + 1`을 통해 다음에 계산할 범위를 `mid`금액보다 크게 좁힙니다.

개인적으로 이분 탐색 시작시에 시작값과 끝값을 찾는 것, 이분 탐색 내에서 탐색 범위를 정하는 부분이 어려웠습니다.