### PR TITLE
PJH - [백준, 7511] 소셜 네트워킹 어플리케이션: 분리 집합 (23분)

### DIFF
--- a/PJH/baekjoon/7511.js
+++ b/PJH/baekjoon/7511.js
@@ -1,0 +1,58 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+function findRoot(node, parent) {
+  if (parent[node] === node) return node;
+  return (parent[node] = findRoot(parent[node], parent));
+}
+
+function union(node1, node2, parent, rank) {
+  const root1 = findRoot(node1, parent);
+  const root2 = findRoot(node2, parent);
+
+  if (root1 === root2) return false;
+
+  if (rank[root1] > rank[root2]) parent[root2] = root1;
+  else {
+    parent[root1] = root2;
+    if (rank[root1] === rank[root2]) rank[root2]++;
+  }
+
+  return true;
+}
+
+const T = Number(input[0]);
+const result = [];
+let i = 1;
+
+for (let t = 1; t <= T; t++) {
+  const n = Number(input[i++]);
+  const k = Number(input[i++]);
+  const edges = [];
+  const currentCase = [];
+
+  for (let j = 0; j < k; j++) {
+    const [a, b] = input[i++].split(" ").map(Number);
+    edges.push([a, b]);
+  }
+
+  const m = Number(input[i++]);
+  const parent = Array.from({ length: n }, (_, i) => i);
+  const rank = Array(n).fill(0);
+
+  for (const [node1, node2] of edges) {
+    union(node1, node2, parent, rank);
+  }
+
+  for (let j = 0; j < m; j++) {
+    const [u, v] = input[i++].split(" ").map(Number);
+
+    if (findRoot(u, parent) === findRoot(v, parent)) currentCase.push(1);
+    else currentCase.push(0);
+  }
+
+  result.push(`Scenario ${t}:\n${currentCase.join("\n")}`);
+}
+
+console.log(result.join("\n\n"));


### PR DESCRIPTION
## PJH - [백준, 7511] 소셜 네트워킹 어플리케이션: 분리 집합 (23분)

### 문제에 대한 한줄 요약
입력으로 주어지는 두 유저 u, v가 서로 친구인지 판별하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 5분
- 2단계 (알고리즘 선택): 1분
- 3단계 (구현 및 테스트): 17분
- 4단계 (디버깅 및 제출): 

### 느낀점
union-find를 통해서 k개의 친구 관계를 모두 판별할 수 있습니다.
union-find에 대해서 간단히 설명하자면 아래와 같은 그래프에선 파란색 집합과 빨간색 집합이 존재하게 됩니다.
<img width="463" height="459" alt="스크린샷 2025-09-26 오후 3 38 06" src="https://github.com/user-attachments/assets/023c2e37-38ec-4407-b577-f9e7f7bd585e" />

특정 노드 u, v가 서로 같은 집합에 있는지 판별하는 방법은 "같은 루트 노드를 바라보는지"를 통해 알 수 있습니다.

예를 들어 파란색 집합에서 2, 3, 4 노드가 각각 노드 1을 루트 노드로 가지고 있다면 1, 2, 3, 4 노드들은 전부 같은 집합에 있다는 것을 알 수 있습니다.
루트 노드에 대한 정보를 저장하는 배열이 `parent` 이고, 위 그래프에 대한 parent 배열을 작성해 보면 아래와 같습니다.
(임의로 1과 5 노드를 루트 노드로 지정했지만, 실제 코드에선 먼저 나오는 노드들에 따라 순서가 달라질 수 있습니다.)
```
parent = [0, 1, 1, 1, 1, 5, 5];
```

루트 노드를 확인하는 것 만으로도 두 노드가 서로 같은 집합에 있는지 확인할 수 있게 됩니다.