### PR TITLE
PJH - [백준, 13265] 색칠하기: 이분 그래프 (bfs) (37분)

### DIFF
--- a/PJH/baekjoon/13265.js
+++ b/PJH/baekjoon/13265.js
@@ -1,0 +1,92 @@
+const fs = require("fs");
+const input = fs.readFileSync("input.txt").toString().trim().split("\n"); // local 파일
+// const input = fs.readFileSync(0, "utf-8").toString().trim().split("\n"); // 문제 제출 시
+
+class Node {
+  constructor(data) {
+    this.data = data;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.front = null;
+    this.rear = null;
+    this.size = 0;
+  }
+
+  push(data) {
+    const newNode = new Node(data);
+
+    if (this.size === 0) {
+      this.front = newNode;
+      this.rear = newNode;
+    } else {
+      this.rear.next = newNode;
+      this.rear = newNode;
+    }
+
+    this.size++;
+  }
+
+  shift() {
+    if (this.size === 0) return null;
+
+    const data = this.front.data;
+
+    this.front = this.front.next;
+    this.size--;
+
+    return data;
+  }
+}
+
+function bfs(start, graph, colors) {
+  const queue = new Queue();
+
+  queue.push(start);
+  colors[start] = 1;
+
+  while (queue.size) {
+    const current = queue.shift();
+
+    for (const next of graph[current]) {
+      if (colors[next] === 0) {
+        colors[next] = 3 - colors[current];
+        queue.push(next);
+      } else if (colors[next] === colors[current]) return false;
+    }
+  }
+
+  return true;
+}
+
+const T = Number(input[0]);
+const result = [];
+let i = 1;
+
+for (let t = 0; t < T; t++) {
+  const [n, m] = input[i++].split(" ").map(Number);
+  const graph = Array.from({ length: n + 1 }, () => []);
+  const colors = Array(n + 1).fill(0);
+  let isBipartite = true;
+
+  for (let j = 0; j < m; j++) {
+    const [x, y] = input[i++].split(" ").map(Number);
+
+    graph[x].push(y);
+    graph[y].push(x);
+  }
+
+  for (let j = 1; j <= n; j++) {
+    if (colors[j] === 0 && !bfs(j, graph, colors)) {
+      isBipartite = false;
+      break;
+    }
+  }
+
+  result.push(isBipartite ? "possible" : "impossible");
+}
+
+console.log(result.join("\n"));


### PR DESCRIPTION
## PJH - [백준, 13265] 색칠하기: 이분 그래프 (bfs) (37분)

### 문제에 대한 한줄 요약
주어진 그래프에서 두가지 색으로만 노드를 칠했을 때 인접한 노드끼리 색이 겹치는지 판별하는 문제입니다.

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 5분
- 2단계 (알고리즘 선택): 3분
- 3단계 (구현 및 테스트): 28분
- 4단계 (디버깅 및 제출): 1분

### 느낀점
주어진 노드들의 색을 저장하는 `colors` 배열을 만들고 값이 0이면 아직 방문하지 않았다는 뜻이고, 1과 2는 각각 다른 색을 의미합니다.

먼저 1번 노드부터 n번 노드까지 반복문을 돌리면서 방문했는지 확인하는데, 문제에서 설명된 것 처럼 모든 노드들에 간선이 연결되어있다고 확정할 수 없기 때문에 전부 다 확인합니다.
만약 방문하지 않았다면 bfs를 통해서 인접한 노드들이 아직 방문하지 않았는지, 현재 노드와 색이 같은지를 판별해 이분 그래프가 되는지 확인하면 됩니다.

구현은 크게 어렵지 않았으나 모든 노드의 방문 여부를 확인해야 하는 점과 bfs로 어떻게 인접 노드들과 색이 겹치지 않는지 판단하는 방법을 생각해야 했던 문제였습니다.