### PR TITLE
JYE - [백준, 27980] 문자열 게임: DP (1시간 30분)

### DIFF
--- a/JYE/baekjoon/27980.java
+++ b/JYE/baekjoon/27980.java
@@ -1,0 +1,76 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        final int ORIGIN_COUNT = Integer.parseInt(st.nextToken());
+        final int TARGET_COUNT = Integer.parseInt(st.nextToken());
+        
+        char[] origin = new char[ORIGIN_COUNT + 1];
+        char[] buffer = br.readLine().toCharArray();
+
+        for (int i = 0; i < ORIGIN_COUNT; i++) {
+            origin[i + 1] = buffer[i];
+        }
+
+        char[] target = new char[TARGET_COUNT + 1];
+        buffer = br.readLine().toCharArray();
+
+        for (int i = 0; i < TARGET_COUNT; i++) {
+            target[i + 1] = buffer[i];
+        }
+
+        int[][] dp = new int[ORIGIN_COUNT + 1][TARGET_COUNT + 1];
+
+        for (int i = 1; i <= ORIGIN_COUNT; i++) {
+            if (origin[i] == target[TARGET_COUNT]) {
+                dp[i][TARGET_COUNT] = 1;
+            }
+        }
+
+        for (int i = TARGET_COUNT - 1; i >= 1; i--) {
+            for (int j = 1; j <= ORIGIN_COUNT; j++) {
+
+                if (j == 1) {
+                    if (target[i] == origin[j]) {
+                        dp[j][i] = dp[j + 1][i + 1] + 1;
+                        continue;
+                    }
+
+                    dp[j][i] = dp[j + 1][i + 1];
+                    continue;
+                } else if (j == ORIGIN_COUNT) {
+                    if (target[i] == origin[j]) {
+                        dp[j][i] = dp[j - 1][i + 1] + 1;
+                        continue;
+                    }
+
+                    dp[j][i] = dp[j - 1][i + 1];
+                    continue;
+                }
+
+                if (target[i] == origin[j]) {
+                    dp[j][i] = Math.max(dp[j - 1][i + 1] + 1, dp[j + 1][i + 1] + 1);
+                    continue;
+                }
+
+                dp[j][i] = Math.max(dp[j - 1][i + 1], dp[j + 1][i + 1]);
+            }
+        }
+
+    
+        int answer = 0;
+
+        for (int i = 1; i <= ORIGIN_COUNT; i++ ) {
+            answer = Math.max(answer, dp[i][1]);
+        }
+
+        System.out.print(answer);
+    }
+
+}


### PR DESCRIPTION
## JYE - [백준, 27980] 문자열 게임: DP (1시간 30분)

### 문제에 대한 한줄 요약
역순으로 생각하기

### 각 단계별 소요 시간

- 1단계 (문제 이해 및 조건 분석): 5분
- 2단계 (알고리즘 선택): 
- 3단계 (구현 및 테스트): 1시간 20분
- 4단계 (디버깅 및 제출): 5분

### 느낀점
아무리 생각해도 정직하게 앞 부분부터 DP를 실행하게 된다면 DP로는 절대로 풀 수 없다고 생각했습니다. (50분 정도)

DP는 작은 값들의 연산의 결과를 추후에 있을 연산에 활용하게 되는데 이를 위해서는 문제를 역순으로 생각을 하는게 딱 들어맞더군요.

그 아이디어를 가지고 푸는게 가장 핵심이지 않았을까 싶습니다.

사고의 유연성이 필요한 문제였습니다.